### PR TITLE
Tmo update ec2 docs fix python order

### DIFF
--- a/src/docs/conf.py
+++ b/src/docs/conf.py
@@ -11,7 +11,7 @@ author = u'Tom Oinn'
 # built documents.
 #
 # The short X.Y version.
-version = '0.2.4'
+version = '0.2.5'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/src/docs/data_provider.rst
+++ b/src/docs/data_provider.rst
@@ -25,7 +25,7 @@ Example data provider
 The example below shows the simplest possible secure application. It configures an instance of
 `AccessTokenValidator` with:
 
-* ``introspection_url`` : The URL of the token introspection endpoint on the authorization server
+* ``issuer_url`` : The URL of the authorization server
 * ``client_id`` : OAuth2 client ID used when making requests to the introspection endpoint
 * ``private_key`` : Location on disk of the private key used when making requests to the introspection endpoint
 * ``certificate`` : Location on disk of the certificate used when making requests to the introspection endpoint

--- a/src/docs/ec2.rst
+++ b/src/docs/ec2.rst
@@ -1,7 +1,7 @@
 Deploying a Data Provider to EC2
 ================================
 
-This guide will show you how to create and deploy a production-grade `Data Provider` to a fresh Amazon
+This guide will show you how to create and deploy a production-grade :term:`data provider` to a fresh Amazon
 `EC2 <https://aws.amazon.com/ec2>`_ instance. By the end of the guide you will have a publicly visible server able to
 publish shared data, secured by the |FAPI| specification as required by Open Energy.
 
@@ -37,6 +37,19 @@ default Python 2 or 3.
     > cd Python-3.9.4
     > sudo ./configure --enable-optimizations
     > sudo make altinstall
+
+All Python code, including the ``gunicorn`` WSGI container, will run from a virtual environment created in the
+``ec2-user`` home directory. Create the environment, activate it, install the necessary libraries, and fetch missing
+root certificates used by the directory - these are necessary for nginx to correctly validate the presented client
+certificates:
+
+.. code-block:: bash
+
+    > cd ~
+    > python3.9 -m venv venv --upgrade-deps
+    > source ./venv/bin/activate
+    > pip install ib1.openenergy.support
+    > oe_install_cacerts
 
 Installing Nginx
 ----------------
@@ -128,8 +141,8 @@ This configuration does a few things.
    but you may want to configure this differently if you also want to serve content to web browsers rather than API
    clients. See the `Nginx docs <http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_verify_client>`_ for more
    information
-3. In order to provide your application with access to the client certificates presented by `Data Consumer` clients, it
-   pushes any such client certificate into a header ``X-OE-CLIENT-CERT``
+3. In order to provide your application with access to the client certificates presented by :term:`data consumer`
+   clients, it pushes any such client certificate into a header ``X-OE-CLIENT-CERT``
 4. It attempts to serve static content from ``/home/ec2-user/public``, and falls back to your data provider application
    if the specified content does not exist, accessing the application through a UNIX socket
 
@@ -231,17 +244,8 @@ you will need to make the corresponding changes there.
 Installing gunicorn and your Data Provider
 ------------------------------------------
 
-All Python code, including the ``gunicorn`` WSGI container, will run from a virtual environment created in the
-``ec2-user`` home directory. Create the environment, activate it, install the necessary libraries, and fetch missing
-root certificates used by the directory:
-
-.. code-block:: bash
-
-    > cd ~
-    > python3.9 -m venv venv --upgrade-deps
-    > source ./venv/bin/activate
-    > pip install ib1.openenergy.support
-    > oe_install_cacerts
+The data provider code uses the virtual environment defined previously. The only remaining tasks are to create the
+necessary configuration for gunicorn and to provide the actual data provider implementation as a Flask app.
 
 gunicorn configuration
 ######################

--- a/src/docs/ec2/data_provider.py
+++ b/src/docs/ec2/data_provider.py
@@ -1,24 +1,12 @@
 import logging
 
 import flask
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 
-from ib1.openenergy.support import AccessTokenValidator
+from ib1.openenergy.support import AccessTokenValidator, nginx_cert_parser
 
 LOG = logging.getLogger('example.energydata.org.uk')
 
 logging.basicConfig(level=logging.INFO)
-
-
-def nginx_cert_parser():
-    """
-    Pull certificate out of X-OE-CLIENT-CERT header from nginx
-    """
-    cert_str = flask.request.headers['X-OE-CLIENT-CERT'].replace('\t', '')
-    LOG.info(f'found cert in header \n{cert_str}')
-    return x509.load_pem_x509_certificate(cert_str.encode('ASCII'), default_backend())
-
 
 validator = AccessTokenValidator(client_id='olQh4BLV0mQUaM3OZbpXy',
                                  certificate='/home/ec2-user/certs/a.pem',

--- a/src/docs/service_provider.rst
+++ b/src/docs/service_provider.rst
@@ -24,7 +24,7 @@ please ask us!) you can configure the `FAPISession` with:
 * ``private_key`` : The file path of the private key
 * ``certificate`` : The file path of the certificate
 * ``client_id`` : The OAuth client ID
-* ``token_url`` : The URL of the token endpoint of the authorization server
+* ``issuer_url`` : The URL of the authorization server
 * ``requested_scopes`` : The OAuth2 scopes to request for any tokens. This should be a string, if multiple scopes are
   required they should be separated by spaces within this string
 

--- a/src/docs/ssl_dev.rst
+++ b/src/docs/ssl_dev.rst
@@ -1,6 +1,11 @@
 Local Data Provider Development Mode
 ====================================
 
+.. deprecated:: 0.2.4
+    As of version 0.2.4 it's possible to run locally within a gunicorn container, as this is equivalently simple to
+    configure and considerably easier to use for unit testing and similar purposes, support for the SSL local dev
+    mode described here should be considered obsolete.
+
 .. warning::
     Please note! This should not be used in production. It is solely to help make your life simpler, when developing a
     :term:`data provider`, by allowing you to run everything locally with full SSL support enabled.

--- a/src/python/ib1/openenergy/support/gunicorn.py
+++ b/src/python/ib1/openenergy/support/gunicorn.py
@@ -51,7 +51,10 @@ class CustomSyncWorker(SyncWorker):
 
 class ClientAuthApplication(gunicorn.app.base.BaseApplication):
     """
-    GUnicorn application using the custom SSL worker. Uses certifi for its CA store.
+    GUnicorn application using the custom SSL worker. Uses certifi for its CA store. This is a helper class, mostly
+    useful when you need to run a data provider as part of a unit test, all it really does is remove the need for a
+    gunicorn.conf.py configuration file. See `this blog <https://eugene.kovalev.systems/blog/flask_client_auth>`_ for
+    more details on how to run a data provider within a test context using this class.
     """
 
     def __init__(self, app, cert_path, key_path, hostname='localhost', port='443', num_workers=4, timeout=30):

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='ib1.openenergy.support',
-    version='0.2.4',
+    version='0.2.5',
     author='Tom Oinn',
     author_email='tom.oinn@icebreakerone.org',
     url='https://github.com/icebreakerone/open-energy-python-infrastructure',


### PR DESCRIPTION
Pushes to v0.2.5, adding a pre-defined certificate parser to handle the way nginx adds random tab characters to its certs when passed through as headers, and incorporating the doc tweaks from Tom H to put the virtual environment setup before the final nginx config so we don't have missing ca roots at that point.