### PR TITLE
Extra metadata logic

### DIFF
--- a/examples/read_write_directory_client.py
+++ b/examples/read_write_directory_client.py
@@ -1,6 +1,8 @@
 import logging
+import logging
 import pprint
-from ib1.openenergy.support import FAPISession, httpclient_logging_patch, build, OpenIDConfiguration
+
+from ib1.openenergy.support import FAPISession, RaidiamDirectory
 
 logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
                     level=logging.DEBUG,
@@ -9,14 +11,38 @@ logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s',
 # httpclient_logging_patch(level=logging.INFO)
 
 # Set up a session, this will get a token from the directory when needed
-f = FAPISession(client_id='4_egpDo0lMugQbMOaNjn0',
-                issuer_url='https://matls-auth.directory.energydata.org.uk',
-                requested_scopes='directory:software',
-                private_key='/home/tom/Desktop/jwt-bearer-certs/transport.key',
-                certificate='/home/tom/Desktop/jwt-bearer-certs/transport.pem')
+jf = FAPISession(client_id='4_egpDo0lMugQbMOaNjn0',
+                 issuer_url='https://matls-auth.directory.energydata.org.uk',
+                 requested_scopes='directory:website',
+                 private_key='/home/tom/Desktop/jwt-bearer-certs/transport.key',
+                 certificate='/home/tom/Desktop/jwt-bearer-certs/transport.pem',
+                 signing_private_key='/home/tom/Desktop/jwt-bearer-certs/signing.key',
+                 jwt_bearer_email='tom.oinn@icebreakerone.org')
 
 # Pretty print the config
 pp = pprint.PrettyPrinter()
-pp.pprint(f.openid_configuration.__dict__)
+pp.pprint(jf.openid_configuration.__dict__)
 # Attempt to introspect on our own token, this causes a request to get the token in the first place
-pp.pprint(f.introspection_response)
+pp.pprint(jf.introspection_response)
+
+DIRECTORY = 'https://matls-dirapi.directory.energydata.org.uk/'
+
+u = f'{DIRECTORY}organisations/8/softwarestatements/0ac540f7-7269-43b5-b4fb-3b06900bf910'
+
+current = jf.session.get(url=u)
+current.raise_for_status()
+j = current.json()
+pp.pprint(j)
+
+org_id = '8'
+directory = RaidiamDirectory(fapi=jf)
+directory.update_client_metadata(org_id=org_id, client_metadata={'something': 'something else'})
+
+#filtered = {k: j[k] for k in j if
+#            k in ['ClientName', 'ClientUri', 'Description', 'Environment', 'LogoUri', 'Mode', 'RedirectUri',
+#                  'TermsOfServiceUri', 'Version', 'AdditionalSoftwareMetadata']}
+#filtered['RedirectUri'] = ['https://fake.example.com']
+#filtered['AdditionalSoftwareMetadata'] = json.dumps({'foo': 'wibble'})
+
+#resp = jf.session.put(url=u, json=filtered)
+#resp.raise_for_status()


### PR DESCRIPTION
Can now push additional client metadata for all clients within a given org in the directory (subject to having an appropriately provisioned client able to use jwt-bearer tokens)