### PR TITLE
Python 3.7 compatibility.

### DIFF
--- a/src/python/ib1/openenergy/support/__init__.py
+++ b/src/python/ib1/openenergy/support/__init__.py
@@ -606,9 +606,9 @@ def build(d: Dict, cls: Type[D], date_format_string='%Y-%m-%dT%H:%M:%S.%fZ') -> 
         return value
 
     known_fields = list(cls.__dataclass_fields__.keys())
-    return cls(**{name: map_field(name, d[key])
+    return cls(**{camelcase_to_python(key): map_field(camelcase_to_python(key), d[key])
                   for key in d
-                  if (name := camelcase_to_python(key)) in known_fields})
+                  if camelcase_to_python(key) in known_fields})
 
 
 class RaidiamDirectory:

--- a/src/python/ib1/openenergy/support/directory_tools.py
+++ b/src/python/ib1/openenergy/support/directory_tools.py
@@ -27,7 +27,8 @@ def get_directory_client(parser=None) -> RaidiamDirectory:
         """
         if f:
             path = abspath(f)
-            if not (file_found := isfile(path)):
+            file_found = isfile(path)
+            if not file_found:
                 LOG.error(f'SSL - {name} = {path} not found!')
             else:
                 LOG.info(f'SSL - {name} = {path}')

--- a/src/python/ib1/openenergy/support/flask_ssl_dev.py
+++ b/src/python/ib1/openenergy/support/flask_ssl_dev.py
@@ -1,11 +1,12 @@
 import logging
 import ssl
 from argparse import ArgumentParser
+from dataclasses import dataclass
 from os.path import abspath, isfile
+
 import certifi
 import werkzeug.serving
 from cryptography import x509
-from dataclasses import dataclass
 
 LOG = logging.getLogger('ib1.oe.support.flask_ssl_dev')
 
@@ -98,7 +99,8 @@ def get_command_line_ssl_args(default_server_private_key='./a.key',
         """
         if f:
             path = abspath(f)
-            if not (file_found := isfile(path)):
+            file_found = isfile(path)
+            if not file_found:
                 LOG.error(f'SSL - {name} = {path} not found!')
             else:
                 LOG.info(f'SSL - {name} = {path}')

--- a/src/python/ib1/openenergy/support/metadata.py
+++ b/src/python/ib1/openenergy/support/metadata.py
@@ -154,10 +154,11 @@ class JSONLDContainer:
         def missing_values():
             for ns, terms in d.items():
                 for term in terms:
-                    if (fterm := f'{ns}{term}') not in self.ld:
+                    fterm = f'{ns}{term}'
+                    if fterm not in self.ld:
                         yield fterm
-
-        if missing := list(missing_values()):
+        missing = list(missing_values())
+        if missing:
             raise ValueError(f'container is missing required values {", ".join(missing)}')
 
     def get(self, namespace: str, term: str, default=None):

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,13 +2,14 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='ib1.openenergy.support',
-    version='0.2.9',
+    version='0.2.10',
     author='Tom Oinn',
     author_email='tom.oinn@icebreakerone.org',
     url='https://github.com/icebreakerone/open-energy-python-infrastructure',
-    description='Flask and Requests extensions to support data providers and clients within the open energy ecosystem',
-    classifiers=['Programming Language :: Python :: 3.8',
-                 'Development Status :: 2 - Pre-Alpha',
+    description='Tools, and Flask and Requests extensions, to support data providers '
+                'and clients within the open energy ecosystem',
+    classifiers=['Programming Language :: Python :: 3.7',
+                 'Development Status :: 4 - Beta',
                  'Framework :: Flask',
                  'License :: OSI Approved :: MIT License',
                  'Topic :: Security',


### PR DESCRIPTION
Compatibility with Python3.7 by removing assignment expressions. Slight  loss of code efficiency in the automated JSON->Dataclass builder but otherwise no significant impacts. Requested by users deploying into Google Colab, a Jupyter based environment which appears to be locked to 3.7.