### PR TITLE
Trivial change to handle inactive software statements

### DIFF
--- a/src/python/ib1/openenergy/support/raidiam.py
+++ b/src/python/ib1/openenergy/support/raidiam.py
@@ -27,7 +27,6 @@ class Organisation:
 @dataclass(frozen=True)
 class SoftwareStatement:
     status: str
-    client_id: str
     client_name: str
     environment: str
     organisation_id: str
@@ -42,6 +41,7 @@ class SoftwareStatement:
     terms_of_service_uri: str = ''
     version: int = 0
     locked: bool = ''
+    client_id: str = None
     redirect_url: List[str] = field(default_factory=list)
 
 


### PR DESCRIPTION
Software statements which are marked as inactive in the directory no longer have associated client_id values, which was causing the previous logic to blow up when encountering them.