### PR TITLE
Fix to metadata validation and resource upload for harvester

### DIFF
--- a/src/python/ib1/openenergy/support/ckan.py
+++ b/src/python/ib1/openenergy/support/ckan.py
@@ -209,7 +209,7 @@ def update_or_create_ckan_record(org: Organisation,
                     **ckan_dict_from_metadata(
                         data_set,
                         description_template=description_template),
-                    resources=resources,
+                    resources=[],
                     owner_org=org.organisation_id,
                     return_package_dict=True)
                 for resource in resources:

--- a/src/python/ib1/openenergy/support/metadata.py
+++ b/src/python/ib1/openenergy/support/metadata.py
@@ -52,17 +52,17 @@ class Metadata:
                                      DC: ['title', 'description'],
                                      OE: ['sensitivityClass', 'dataSetStableIdentifier']})
 
-        if 'transport' not in d:
-            raise ValueError('no transport item defined')
-        self.transport = d['transport']
+        def require_dict(keyname: str):
+            if keyname not in d:
+                raise ValueError(f'no {keyname} section defined')
+            result = d['keyname']
+            if not isinstance(result, dict):
+                raise ValueError(f'{keyname} does not contain nested content')
+            return result
 
-        if 'access' not in d:
-            raise ValueError('no access item defined')
-        self.access = d['access']
-
-        if 'representation' not in d:
-            raise ValueError('no representation item defined')
-        self.representation = d['representation']
+        self.transport = require_dict('transport')
+        self.access = require_dict('access')
+        self.representation = require_dict('representation')
 
     @property
     def mime(self) -> str:
@@ -157,6 +157,7 @@ class JSONLDContainer:
                     fterm = f'{ns}{term}'
                     if fterm not in self.ld:
                         yield fterm
+
         missing = list(missing_values())
         if missing:
             raise ValueError(f'container is missing required values {", ".join(missing)}')


### PR DESCRIPTION
@KKulma this should fix the harvester problems. Some were because we were triggering a bug in the CKAN API, I'd worked around this when updating but not when creating new sets. The other issues were due to not catching invalid metadata files early enough - some had an 'transport' element but it was empty so we then failed when looking for anything inside it. The code now checks that all these elements not only exist, but contain dicts.