### PR TITLE
Clean up metadata validation

### DIFF
--- a/src/python/ib1/openenergy/support/metadata_harvester.py
+++ b/src/python/ib1/openenergy/support/metadata_harvester.py
@@ -58,12 +58,14 @@ def check_metadata():
                          'individual metadata file locations for compatibility with the harvester.'
     parser.add_argument('-l', '--log_level', type=str, help='log level, defaults to ERROR', default='ERROR',
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'])
-    parser.add_argument('-u', '--url', type=str, help='url for metadata file', required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-u', '--url', type=str, help='url for metadata file', default=None)
+    group.add_argument('-f', '--file', type=str, help='file location for metadata file', default=None)
     parser.add_argument('-t', '--template', type=str, help='location for a Jinja2 template on disk to use',
                         default=None, required=False)
     options = parser.parse_args()
     configure_logging(options)
-    result = load_metadata(url=options.url)
+    result = load_metadata(url=options.url, file=options.file)
     print(f'Metadata load result [{"error" if result.error else "success"}]:')
     print(result)
 
@@ -153,13 +155,14 @@ def build_report_csv(org_to_reports: Dict[Organisation, List[MetadataLoadResult]
         :return:
             dict of items to add to a single row in the report
         """
+        error_string = f'{rep.error} : {str(rep.exception)}' if rep.error else ''
         return {
             'org_id': o.organisation_id,
             'org_name': o.organisation_name,
             'success': rep.error is None,
             'auth_server_id': rep.server.authorisation_server_id,
             'metadata_location': rep.location,
-            'error': rep.error,
+            'error': error_string,
             'ckan_dataset_name': ckan_dataset_name(org=org, data_set=meta) if meta else '',
             'ckan_dataset_title': meta.title if meta else ''
         }

--- a/src/python/ib1/openenergy/support/metadata_harvester.py
+++ b/src/python/ib1/openenergy/support/metadata_harvester.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Tuple, Generator, Optional
 import jinja2
 from jinja2 import TemplateNotFound, Template
 
-from ib1.openenergy.support import RaidiamDirectory
+from ib1.openenergy.support import RaidiamDirectory, httpclient_logging_patch
 from ib1.openenergy.support.ckan import update_or_create_ckan_record, ckan_dataset_name, ckan_dict_from_metadata
 from ib1.openenergy.support.directory_tools import get_directory_client
 from ib1.openenergy.support.metadata import Metadata, load_metadata, MetadataLoadResult
@@ -29,7 +29,13 @@ def configure_logging(options):
             return logging.WARNING
         return logging.ERROR
 
-    logging.basicConfig(level=level())
+    # Enable logging for httpclient at debug level
+    httpclient_logging_patch(level=logging.DEBUG)
+
+    # Configure logging with timestamps etc
+    logging.basicConfig(level=level(),
+                        format='%(asctime)s %(levelname)-8s %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S')
 
 
 def get_template(options) -> Optional[Template]:


### PR DESCRIPTION
* Validates correctly (looks for list in access section and dicts in transport and representation)
* Finds all errors in a metadata block rather than stopping at the first one, producing better reporting
* Pushes error details to CSV format output from harvester
* Finds errors in multiple metadata blocks rather than stopping at the first failed block in a file