### PR TITLE
Report partial success properly

### DIFF
--- a/src/python/ib1/openenergy/support/metadata.py
+++ b/src/python/ib1/openenergy/support/metadata.py
@@ -234,6 +234,7 @@ class MetadataLoadResult:
     exception: Exception = None
     metadata: List[Metadata] = field(default_factory=list)
     server: AuthorisationServer = None
+    metadata_records_found: int = 0
 
     def __repr__(self):
         from pprint import pformat
@@ -365,13 +366,15 @@ def load_metadata(server: AuthorisationServer = None, url: str = None, file: str
                         yield Metadata(item)
                     except ValueError as ve:
                         errors.append(f'Unable to parse metadata item {index} : {str(ve)}')
+
             metadata_items = list(build_metadata())
             if errors:
                 raise ValueError('. '.join(errors))
-            return MetadataLoadResult(location=location, metadata=metadata_items, server=server)
+            return MetadataLoadResult(location=location, metadata=metadata_items, server=server,
+                                      metadata_records_found=len(result))
         except ValueError as ve:
             return MetadataLoadResult(location=location, error='invalid metadata description', exception=ve,
-                                      server=server)
+                                      server=server, metadata_records_found=len(result))
 
     # No list item, this is a failure
     return MetadataLoadResult(location=location, error='metadata does not contain a list as top level item',

--- a/src/python/ib1/openenergy/support/metadata_harvester.py
+++ b/src/python/ib1/openenergy/support/metadata_harvester.py
@@ -166,6 +166,8 @@ def build_report_csv(org_to_reports: Dict[Organisation, List[MetadataLoadResult]
             'org_id': o.organisation_id,
             'org_name': o.organisation_name,
             'success': rep.error is None,
+            'records_found': rep.metadata_records_found,
+            'records_imported': len(rep.metadata),
             'auth_server_id': rep.server.authorisation_server_id,
             'metadata_location': rep.location,
             'error': error_string,
@@ -174,7 +176,8 @@ def build_report_csv(org_to_reports: Dict[Organisation, List[MetadataLoadResult]
         }
 
     si = StringIO()
-    cw = csv.DictWriter(si, fieldnames=['org_id', 'org_name', 'success', 'auth_server_id', 'metadata_location', 'error',
+    cw = csv.DictWriter(si, fieldnames=['org_id', 'org_name', 'success', 'records_found', 'records_imported',
+                                        'auth_server_id', 'metadata_location', 'error',
                                         'ckan_dataset_name', 'ckan_dataset_title'], dialect=dialect)
     cw.writeheader()
     for org, reports in org_to_reports.items():


### PR DESCRIPTION
This adds two columns to the CSV report to indicate the number of metadata records in the file, and the number successfully imported. The overall 'success' flag is only set if there are no errors, but it's now possible that a partial import has worked and picked up some but not all of the metadata objects in the file, this allows us to see this.