### PR TITLE
Improve updating CKAN resources

### DIFF
--- a/src/python/ib1/openenergy/support/ckan.py
+++ b/src/python/ib1/openenergy/support/ckan.py
@@ -208,6 +208,9 @@ def update_or_create_ckan_record(org: Organisation,
                             existing_resources.pop(res_name)
                         else:
                             ckan.action.resource_create(**resource)
+                    # While we use package_update(), the block below deleting resources might be
+                    # unnecessary, but if we use package_patch() instead we will need it.  Before
+                    # deleting this, check it doesn't leave orphaned resources.
                     for obsolete_resource_name in existing_resources:
                         obsolete_resource = existing_resources[obsolete_resource_name]
                         ckan.action.resource_delete(id=obsolete_resource['id'])

--- a/src/python/ib1/openenergy/support/ckan.py
+++ b/src/python/ib1/openenergy/support/ckan.py
@@ -188,18 +188,29 @@ def update_or_create_ckan_record(org: Organisation,
 
                 # Check whether the data package already exists in CKAN
                 try:
-                    ckan.action.package_show(id=dataset_id)
+                    existing_package = ckan.action.package_show(id=dataset_id)
                     LOG.info(f'data package id={dataset_id} already exists in CKAN, updating')
                     # Found existing package, use package update
                     result = ckan.action.package_update(name=dataset_id,
                                                         **ckan_dict_from_metadata(
                                                             data_set,
                                                             description_template=description_template),
-                                                        resources=[],
                                                         owner_org=org.organisation_id,
                                                         return_package_dict=True)
+                    existing_resources = { res['name']: res for res in existing_package['resources'] }
                     for resource in resources:
-                        ckan.action.resource_create(**resource)
+                        res_name = resource['name']
+                        if res_name in existing_resources:
+                            res_id = existing_resources[res_name]['id']
+                            # package_update() above removes any existing resources,
+                            # so create a new resource with the previously existing ID.
+                            ckan.action.resource_create(id=res_id, **resource)
+                            existing_resources.pop(res_name)
+                        else:
+                            ckan.action.resource_create(**resource)
+                    for obsolete_resource_name in existing_resources:
+                        obsolete_resource = existing_resources[obsolete_resource_name]
+                        ckan.action.resource_delete(id=obsolete_resource['id'])
                     yield result
                 except NotFound:
                     # Not found in CKAN, use package_create to build a new one
@@ -209,7 +220,6 @@ def update_or_create_ckan_record(org: Organisation,
                         **ckan_dict_from_metadata(
                             data_set,
                             description_template=description_template),
-                        resources=[],
                         owner_org=org.organisation_id,
                         return_package_dict=True)
                     for resource in resources:


### PR DESCRIPTION
Each CKAN data set might have one or more resources.  Previously, the
code disregarded any existing resources and recreated them with a new
ID.  This broke bookmarking resource URLs and following links to
resources if when the shared data harvester runs in between generating
links and requesting them.

This commit retains the IDs, and consequently URLs, of resources, but it
does so by removing them briefly before recreating them with their
previous IDs.  Calling package_patch() instead of package_update() might
help with this, but when I tried this the CKAN client disliked the
StringIO objects.  It's also possible that package_patch() would handle
fields removed from the metadata badly, by leaving them intact instead
of removing them, so we'd need to think carefully about the logic of
this approach.