### PR TITLE
An organisation might not have a registered name

### DIFF
--- a/src/python/ib1/openenergy/support/raidiam.py
+++ b/src/python/ib1/openenergy/support/raidiam.py
@@ -13,11 +13,11 @@ class Organisation:
     country_of_registration: str
     company_register: str
     registration_number: str
-    registered_name: str
     city: str
     postcode: str
     country: str
     requires_participant_terms_and_conditions_signing: bool
+    registered_name: str = ''
     registration_id: str = ''
     address_line1: str = ''
     address_line2: str = ''


### PR DESCRIPTION
Ensure we treat this field as optional to prevent the metadata harvester failing when it encounters organisations without this field set.