### PR TITLE
urllib3 update causing an error

### DIFF
--- a/icebreakerone/trust/__init__.py
+++ b/icebreakerone/trust/__init__.py
@@ -26,7 +26,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
 from requests.exceptions import RetryError
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 import icebreakerone.trust.raidiam as raidiam
 
@@ -334,7 +334,7 @@ class FAPISession(AuthBase):
         # Configure retries
         retry_strategy = Retry(total=retries,
                                status_forcelist=[429, 502, 503, 504],
-                               method_whitelist=["HEAD", "GET", "OPTIONS"],
+                               allowed_methods=["HEAD", "GET", "OPTIONS"],
                                backoff_factor=1)
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self._session.mount('https://', adapter)


### PR DESCRIPTION
A deprecated `Retry` option `method_whitelist` was removed in a recent urllib3 release, I've updated the option to the new name `allowed_methods`, and also switched to importing from urllib3 directly rather than via the Requests package